### PR TITLE
memory_alignment.c: suggestion to fix potentially dangling pointer in…

### DIFF
--- a/memory_alignment.c
+++ b/memory_alignment.c
@@ -58,12 +58,14 @@ void* mallo_32_aligned(size_t size){
     return align_p;
 }
 
-void free_32_aligned(void* aligned_p){
-    void** p = aligned_p;
-    aligned_p = NULL;
+void free_32_aligned(void** aligned_pp) {
+    if (!aligned_pp || !*aligned_pp) return;  // handle NULL pointers
+
+    void** p = *aligned_pp;
     void* notaligned_p = (void*)p[-1];
-    printf("Restored pointer: %p \n",notaligned_p);
+    printf("Restored pointer: %p \n", notaligned_p);
     free(notaligned_p);
+    *aligned_pp = NULL;  // Nullify the original pointer
 }
 
 int main() {


### PR DESCRIPTION
… free_32_aligned

Interesting exercise. From my POV in the original function, only the local copy of the parameter is NULLed (because of the behavior of C). Therefore, passing now a pointer to the pointer. Also added a safety check to the beginning.

Note: untested code. Also: the call has to be adapted.